### PR TITLE
BUG: Allowed ping action to Security controller

### DIFF
--- a/code/SSPSecurity.php
+++ b/code/SSPSecurity.php
@@ -44,7 +44,8 @@ class SSPSecurity extends Controller {
         'index',
         'login',
         'logout',
-        'loggedout'
+        'loggedout',
+        'ping'
     );
 
     public function init() {


### PR DESCRIPTION
The CMS does /Security/ping to keep the session alive. This was redirecting users through SSO authentication if not allowed.
