### PR TITLE
php-openid requirement is not needed anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
 		"php": ">=5.3",
 		"composer/installers": "*",
 		"silverstripe/framework": "3.1.*",
-		"openid/php-openid": "dev-master#ee669c6a9d4d95b58ecd9b6945627276807694fb as 2.2.2",
 		"simplesamlphp/saml2": "~0.3",
 		"simplesamlphp/xmlseclibs": "1.3.2",
 		"simplesamlphp/simplesamlphp": "1.13.2"


### PR DESCRIPTION
See https://github.com/simplesamlphp/simplesamlphp/commit/1ecca1ee0f5fb960a274bacb0ba59de73d466075

Let's users install the module without having ext-gmp installed (composer)
